### PR TITLE
[POZ-27] Home button with routes going back and forth in to create

### DIFF
--- a/front-end/src/App.vue
+++ b/front-end/src/App.vue
@@ -1,17 +1,28 @@
 <template>
   <v-app>
-    <v-main>
-      <router-view />
-    </v-main>
+     <v-row>
+      <v-col md="3">
+        <nav-sidebar></nav-sidebar>
+      </v-col>
+      <v-col md="6">
+        <v-main>
+          <router-view />          
+        </v-main>
+      </v-col>
+    </v-row>
   </v-app>
 </template>
 
 <script>
+import NavSidebar from "@/components/NavSidebar.vue";
 export default {
   name: "App",
 
   data: () => ({
     //
   }),
+  components:{
+    NavSidebar
+  },
 };
 </script>

--- a/front-end/src/components/NavSidebar.vue
+++ b/front-end/src/components/NavSidebar.vue
@@ -1,0 +1,73 @@
+<template>
+    <div>
+        <v-card width="250px" height="100vh">
+          <!-- This is the side-bar implemenatation -->
+          <!-- <v-card> -->
+            <v-navigation-drawer
+            permanent
+            left>
+              <v-list-item>
+              <!-- this list item content is the top of the side bar component -->
+                <v-list-item-content>
+                <!-- Title sub componenet of sidebar -->
+                  <v-list-item-title class="text-h6">
+                    Application
+                  </v-list-item-title>
+                  <!-- sub component -->
+                  <v-list-item-subtitle>
+                  subtext 
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+
+              <v-divider></v-divider>
+              <!-- This v-list item containts the actual side bar options  -->
+              <!-- javascript in vue tags we loop option in sidebarOptions -->
+              <!-- the key option.title is effectively a primary key it needs 
+              to be there to access the elements of the array i.e. sidebarOptions -->
+              <!-- The v-for and key makes the v-list item loop for however many
+                items in the list  -->
+              <v-list
+                dense
+                nav
+                v-for="option in sidebarOptions"
+                :key="option.title"
+              >
+                <!-- Below is where you would provide the items for the list -->
+                <!--  -->
+                
+                <v-list-item link>
+                  <v-list-item-icon>
+                      <v-icon>
+                      {{ option.icon }}
+                      </v-icon>
+                  </v-list-item-icon>
+
+                    <v-list-item-title>
+                    {{ option.title }}
+                    </v-list-item-title>
+                </v-list-item>
+              </v-list>
+              
+            </v-navigation-drawer>
+        </v-card> 
+    </div>
+</template>
+<script>
+export default {
+  data(){
+      return{
+        sidebarOptions: [
+          { title: "Home", icon: "mdi-folder" },
+          { title: "Account", icon: "mdi-account-multiple" },
+          { title: "Favorites", icon: "mdi-star" },
+          { title: "Back", icon: "mdi-arrow-left" },
+          { title: "Shared with me", icon: "mdi-account-multiple" },
+          { title: "Starred", icon: "mdi-star" },
+          { title: "My Files", icon: "mdi-folder" },
+        ],
+      }
+  }
+}
+</script>
+<style scoped></style>

--- a/front-end/src/router/index.js
+++ b/front-end/src/router/index.js
@@ -14,6 +14,7 @@ const routes = [
   {
     path: "/",
     name: "Home",
+    alias: "/home",
     component: Home,
   },
   {

--- a/front-end/src/views/Home.vue
+++ b/front-end/src/views/Home.vue
@@ -7,7 +7,7 @@
             <div class="text-xs-center">
               <router-link to="/create" tag="button">
                 <v-btn  class="mx-auto" id="button-create" color="orange">
-                  Create New
+                  New Canvas
                 </v-btn>
               </router-link>
             </div>

--- a/front-end/src/views/Home.vue
+++ b/front-end/src/views/Home.vue
@@ -5,7 +5,7 @@
         <v-layout align-center justify-center>
           <v-flex xs6>
             <div class="text-xs-center">
-              <router-link to="/create" tag="button">
+              <router-link to="/create" >
                 <v-btn  class="mx-auto" id="button-create" color="orange">
                   New Canvas
                 </v-btn>

--- a/front-end/src/views/Home.vue
+++ b/front-end/src/views/Home.vue
@@ -1,13 +1,32 @@
 <template>
-  <div>Home page</div>
+  <div>
+    <v-main>
+      <v-container fill-height>
+        <v-layout align-center justify-center>
+          <v-flex xs6>
+            <div class="text-xs-center">
+              <router-link to="/create" tag="button">
+                <v-btn  class="mx-auto" id="button-create" color="orange">
+                  Create New
+                </v-btn>
+              </router-link>
+            </div>
+          </v-flex>
+        </v-layout>
+      </v-container>
+    </v-main>
+  </div>
 </template>
 
 <script>
+
 export default {
   name: "Home",
   props: {},
   data() {
     return {};
+  },
+  components:{
   },
   computed: {},
   methods: {},

--- a/front-end/src/views/create/Billboard.vue
+++ b/front-end/src/views/create/Billboard.vue
@@ -48,14 +48,14 @@
               <v-row class="mb-6">
                 <v-col md="1" offset-md="8">
                   <div>
-                    <router-link to="/" tag="button">
+                    <router-link to="/">
                       <v-btn>Cancel</v-btn>
                     </router-link>
                   </div>
                 </v-col>
                 <v-col md="1" offset-md="1">
                   <div>
-                    <router-link to="/create/2" tag="button">
+                    <router-link to="/create/2">
                       <v-btn color="orange">Next</v-btn>
                     </router-link>
                   </div>

--- a/front-end/src/views/create/Billboard.vue
+++ b/front-end/src/views/create/Billboard.vue
@@ -11,58 +11,6 @@
         </h2>
         <!-- The no gutters removes negative margins and padding -->
         <v-row no-gutters>
-        <!-- This v-col is responsible for the spaceing of the side bar via cols -->
-          <v-col cols="8" sm="2">
-          <!-- This is the side-bar implemenatation -->
-            <v-card>
-              <v-navigation-drawer permanent>
-                <v-list-item>
-                <!-- this list item content is the top of the side bar component -->
-                  <v-list-item-content>
-                  <!-- Title sub componenet of sidebar -->
-                    <v-list-item-title class="text-h6">
-                      Application
-                    </v-list-item-title>
-                    <!-- sub component -->
-                    <v-list-item-subtitle>
-                    subtext 
-                    </v-list-item-subtitle>
-                  </v-list-item-content>
-                </v-list-item>
-
-                <v-divider></v-divider>
-                <!-- This v-list item containts the actual side bar options  -->
-                <!-- javascript in vue tags we loop option in sidebarOptions -->
-                <!-- the key option.title is effectively a primary key it needs 
-                to be there to access the elements of the array i.e. sidebarOptions -->
-                <!-- The v-for and key makes the v-list item loop for however many
-                  items in the list  -->
-                <v-list
-                  dense
-                  nav
-                  v-for="option in sidebarOptions"
-                  :key="option.title"
-                >
-                  <!-- Below is where you would provide the items for the list -->
-                  <!--  -->
-                  
-                  <v-list-item link>
-                    <v-list-item-icon>
-                       <v-icon>
-                       {{ option.icon }}
-                        </v-icon>
-                    </v-list-item-icon>
-
-                      <v-list-item-title>
-                      {{ option.title }}
-                      </v-list-item-title>
-                  </v-list-item>
-                </v-list>
-               
-                
-              </v-navigation-drawer>
-            </v-card>
-          </v-col> 
           <!-- side bar ends here -->
 
           <!-- Poster options begin -->
@@ -100,12 +48,16 @@
               <v-row class="mb-6">
                 <v-col md="1" offset-md="8">
                   <div>
-                    <v-btn>Cancel</v-btn>
+                    <router-link to="/" tag="button">
+                      <v-btn>Cancel</v-btn>
+                    </router-link>
                   </div>
                 </v-col>
                 <v-col md="1" offset-md="1">
                   <div>
-                    <v-btn color="orange"> Next </v-btn>
+                    <router-link to="/create/2" tag="button">
+                      <v-btn color="orange">Next</v-btn>
+                    </router-link>
                   </div>
                 </v-col>
               </v-row>
@@ -130,24 +82,6 @@ export default {
     return {
       billboard: {},
       billboards: [],
-      // The options for sidebar options housed in this array
-      sidebarOptions: [
-        { title: "Home", icon: "mdi-folder" },
-        { title: "Account", icon: "mdi-account-multiple" },
-        { title: "Favorites", icon: "mdi-star" },
-        { title: "Back", icon: "mdi-arrow-left" },
-        { title: "Shared with me", icon: "mdi-account-multiple" },
-        { title: "Starred", icon: "mdi-star" },
-        { title: "My Files", icon: "mdi-folder" },
-        { title: "Shared with me", icon: "mdi-account-multiple" },
-        { title: "Starred", icon: "mdi-star" },
-        { title: "My Files", icon: "mdi-folder" },
-        { title: "Shared with me", icon: "mdi-account-multiple" },
-        { title: "Starred", icon: "mdi-star" },
-        { title: "My Files", icon: "mdi-folder" },
-        { title: "Shared with me", icon: "mdi-account-multiple" },
-        { title: "Starred", icon: "mdi-star" },
-      ],
       // This cards correspond to the 4 poster options
       cards: [
         {


### PR DESCRIPTION
## Link Jira ticket:
https://jess-nguy.atlassian.net/browse/POZ-27

## Author Notes:
- Renamed the `Create New` To be `New Canvas` since it isn't clear what new things it would be creating.
- made ui for home with the button to create  new canvas
-  moved the sidebar to a component to be called at the root vue file
- add working routes back and forth from `/home` or `/` to `/create` and to `/create/2`

## PREVIEW:
![image](https://user-images.githubusercontent.com/38814279/158938937-bf854b40-8877-42ae-8192-24712779c1c3.png)

![image](https://user-images.githubusercontent.com/38814279/158938923-c1926a62-3aa2-4ef6-bd71-15dc4935d692.png)

## Impacts and Notes:
- this  changes the sidebar works but there weren't any clickables so it shouldn't have broken anything.

## Testing Guidance:
Open `localhost:8080` To see home
Make sure the sidebar is visible no matter the url. Whether it exists or not
Make sure the `New Canvas`, `Cancel`, and `Next` button works.

## Author Checklist:

- [x] Tested locally.
- [x] Change Jira ticket status to into Review.
- [x] _Updated the documentation_. NO docs needs updating for this PR
